### PR TITLE
updated to SimpleInjector 5

### DIFF
--- a/Rebus.SimpleInjector.Tests/Rebus.SimpleInjector.Tests.csproj
+++ b/Rebus.SimpleInjector.Tests/Rebus.SimpleInjector.Tests.csproj
@@ -53,8 +53,8 @@
     </PackageReference>
     <PackageReference Include="Rebus" Version="6.0.0" />
     <PackageReference Include="Rebus.Tests.Contracts" Version="6.0.0" />
-    <PackageReference Include="simpleinjector" Version="4.0.8" />
-    <PackageReference Include="SimpleInjector.Packaging" Version="4.0.8" />
+    <PackageReference Include="simpleinjector" Version="5.0.2" />
+    <PackageReference Include="SimpleInjector.Packaging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Rebus.SimpleInjector.Tests/SimpleInjectorActivationContext.cs
+++ b/Rebus.SimpleInjector.Tests/SimpleInjectorActivationContext.cs
@@ -73,7 +73,7 @@ namespace Rebus.SimpleInjector.Tests
 
                     Console.WriteLine("Registering {0} => {1}", serviceType, string.Join(", ", a));
 
-                    container.RegisterCollection(serviceType, a.Select(g => g.ConcreteType));
+                    container.Collection.Register(serviceType, a.Select(g => g.ConcreteType));
                 }
             }
 

--- a/Rebus.SimpleInjector/Rebus.SimpleInjector.csproj
+++ b/Rebus.SimpleInjector/Rebus.SimpleInjector.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rebus" Version="6.0.0" />
-    <PackageReference Include="simpleinjector" Version="4.0.8" />
+    <PackageReference Include="simpleinjector" Version="5.0.2" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
Fix to #9.
2 tests not pass. It complains on disposing transient object.
I tried to fix it but gave up. This is only a warning and as I can understand
requires to fix Rebus container integration tests.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
