### PR TITLE
#15 fix url

### DIFF
--- a/Rebus.SimpleInjector/Rebus.SimpleInjector.csproj
+++ b/Rebus.SimpleInjector/Rebus.SimpleInjector.csproj
@@ -9,7 +9,7 @@
 		<PackageDescription>Provides a SimpleInjector container adapter for Rebus</PackageDescription>
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus simple-injector simpleinjector ioc dependency-injection</PackageTags>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.SimpleInjector</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #15 